### PR TITLE
Add --undo flag to push command to revert last push

### DIFF
--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -5,6 +5,7 @@ import { confirmAction } from "../utils/prompts.js";
 import { WordPressClient } from "../services/wordpress-client.js";
 import { LocalStore } from "../services/local-store.js";
 import { ElementorParser } from "../services/elementor-parser.js";
+import { RevisionManager } from "../services/revision-manager.js";
 
 export const pushCommand = new Command("push")
   .description("Upload local changes to WordPress")
@@ -13,6 +14,7 @@ export const pushCommand = new Command("push")
   .option("-a, --all", "Push all locally modified pages")
   .option("-f, --force", "Force push even if remote has changed")
   .option("-n, --dry-run", "Show what would be pushed without making changes")
+  .option("-u, --undo", "Undo the last push by restoring the previous revision")
   .addHelpText(
     "after",
     `
@@ -23,11 +25,14 @@ Examples:
   $ elementor-cli push 42 --force            Overwrite remote changes
   $ elementor-cli push 42 --dry-run          Preview changes
   $ elementor-cli push 42 --site production  Push to specific site
+  $ elementor-cli push 42 --undo             Undo last push for page
+  $ elementor-cli push 42 --undo --dry-run   Preview what undo would restore
 
 Safety features:
   - Compares timestamps to detect conflicts
   - Requires --force if remote has been modified
   - WordPress creates a revision before overwriting
+  - Use --undo to revert a push to the previous revision
 
 See also:
   elementor-cli pull           Download pages
@@ -56,6 +61,94 @@ See also:
       } else {
         logger.error("Please specify page ID(s) or use --all flag.");
         process.exit(1);
+      }
+
+      // Undo mode: restore pages to the revision created before the last push
+      if (options.undo) {
+        const manager = new RevisionManager(client);
+        let restored = 0;
+        let skipped = 0;
+
+        for (const pageId of pagesToPush) {
+          const spinner = logger.spinner(`Fetching revisions for page ${pageId}...`);
+
+          try {
+            const revisions = await manager.listRevisions(pageId);
+
+            // Find the most recent revision with Elementor data
+            const revision = revisions.find((rev) => rev.hasElementorData);
+            if (!revision) {
+              spinner.fail(`No revision with Elementor data found for page ${pageId}.`);
+              skipped++;
+              continue;
+            }
+
+            spinner.stop();
+            logger.info(
+              `Page ${pageId}: found revision ${revision.id} from ${formatDate(revision.date)}`
+            );
+
+            if (options.dryRun) {
+              // Show what the undo would restore
+              const currentPage = await client.getPage(pageId);
+              const currentData = parser.parseWPPage(currentPage);
+              const diff = parser.diffElements(
+                currentData.elementor_data,
+                revision.elementorData
+              );
+
+              if (diff.added.length || diff.removed.length || diff.modified.length) {
+                logger.dim(
+                  `  Would revert: +${diff.added.length} added, -${diff.removed.length} removed, ~${diff.modified.length} modified`
+                );
+              } else {
+                logger.dim(`  No differences between current and revision.`);
+              }
+
+              skipped++;
+              continue;
+            }
+
+            if (!options.force) {
+              const confirmed = await confirmAction(
+                `Restore page ${pageId} to revision ${revision.id}? Current remote content will be overwritten.`
+              );
+              if (!confirmed) {
+                logger.dim(`Skipped page ${pageId}`);
+                skipped++;
+                continue;
+              }
+            }
+
+            const restoreSpinner = logger.spinner(`Restoring page ${pageId} to revision ${revision.id}...`);
+
+            await manager.restoreRevision(pageId, revision.id);
+
+            // Update local store with the restored state
+            const restoredPage = await client.getPage(pageId);
+            const restoredData = parser.parseWPPage(restoredPage);
+            await store.savePage(siteName, restoredData);
+
+            restoreSpinner.succeed(
+              `Restored page ${pageId} to revision ${revision.id} (${formatDate(revision.date)})`
+            );
+            restored++;
+          } catch (error) {
+            spinner.fail(`Failed to undo push for page ${pageId}: ${error}`);
+          }
+        }
+
+        console.log("");
+        if (options.dryRun) {
+          logger.info(
+            `Dry run complete. ${pagesToPush.length} page(s) would be restored.`
+          );
+        } else {
+          logger.success(
+            `Restored ${restored} page(s)${skipped > 0 ? `, skipped ${skipped}` : ""}`
+          );
+        }
+        return;
       }
 
       let pushed = 0;

--- a/tests/e2e/pull-push-diff.test.ts
+++ b/tests/e2e/pull-push-diff.test.ts
@@ -204,6 +204,60 @@ describe("E2E: pull/push/diff commands", () => {
       // Push shows a warning for non-existent local pages
       expect(output).toContain("not found locally");
     });
+
+    test("undo restores page to previous revision", async () => {
+      // Pull a page
+      await runCli(["pull", String(env.pages.simple), "--site", "test"]);
+
+      // Modify and push so a revision gets created
+      const elementsPath = join(
+        TEST_PAGES_DIR,
+        "pages",
+        "test",
+        String(env.pages.simple),
+        "elements.json"
+      );
+      const elements = await Bun.file(elementsPath).json();
+      if (elements[0]?.elements?.[0]?.settings) {
+        elements[0].elements[0].settings.title = "Undo Test " + Date.now();
+      }
+      await Bun.write(elementsPath, JSON.stringify(elements, null, 2));
+
+      await runCli([
+        "push",
+        String(env.pages.simple),
+        "--site",
+        "test",
+        "--force",
+      ]);
+
+      // Undo the push
+      const { output, exitCode } = await runCli([
+        "push",
+        String(env.pages.simple),
+        "--site",
+        "test",
+        "--undo",
+        "--force",
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(output).toContain("Restored");
+    });
+
+    test("undo dry-run previews without restoring", async () => {
+      const { output, exitCode } = await runCli([
+        "push",
+        String(env.pages.simple),
+        "--site",
+        "test",
+        "--undo",
+        "--dry-run",
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(output).toContain("Dry run complete");
+    });
   });
 
   describe("diff", () => {


### PR DESCRIPTION
Adds a -u/--undo flag that restores a page to its most recent WordPress
revision (the state before the last push). Supports --dry-run to preview
what would be restored and --force to skip confirmation prompts.
Also updates local store after restore to keep local files in sync.

https://claude.ai/code/session_01Nfm3TeP8MLtQaGEs9Yjb1M